### PR TITLE
Moves html to content to markdown files

### DIFF
--- a/content/projects.md
+++ b/content/projects.md
@@ -1,0 +1,3 @@
+### Projects
+
+Work that I'm doing or have done in the past and I consider them usable pieces of software.

--- a/content/projects/habit-tracker/change-log.md
+++ b/content/projects/habit-tracker/change-log.md
@@ -1,0 +1,28 @@
+## Change Log
+
+### v1.0.0 - Activities and Journal Entries
+
+#### Motivation
+
+Want to introduce a journaling habit through this project and considered to write my daily journal entries in a separate file called `journal.txt` and parse that similarly to a `user_input` file. However, I think it might just get a little too messy with multiple `user_input` files, so the solution is the bake the daily journal entries into the already existing `user_input` file format.
+
+This is starting to get closer to the idea of habit journal. Whereby I have my habits, and a journal for each day so that I can introduce a more personal way of recording my activities. Would be nice to see my journal entries in the context of my habits, and see if there's any correlation between the two.
+
+And to be honest the editing longer text with the wrap flag on here in Vim doesn't seem that bad. The main reason for this feature is to allow the user to get into the habit of Journaling in a very simple way. There's no need for fancy text editors or cool apps, I think the important bit is to get your thoughts down and be able to dig them up using date filter for example.
+
+#### Theoretical Solution
+
+Currently we have the `data.txt` file that contains all the data that is entered into the Habits database (activities). Now that we're doing journaling in the same application, we need more complex storage file structure:
+
+1. `activity.txt` contains the activities just as how it was the `data.txt`
+2. `journal_entry.txt` contains the journal entries, with an `id`, `record_date` and `record`
+
+With this I'm creating a dependency to the `user_input` files and their parsing. But that's alright, because a CLI needs to be implemented anyway and that can have features that allow users to introduce their activities and journal entries outside of these user files. As long as we agree that the source of truth for the data is the database, or perhaps the database files: `activity.txt` and `journal.txt` at the early stages of the project.
+
+Mixing the 2 concepts (`activity` and `journal_entry`) into a single user input file is a good first solution, but later on I can create another file that supports Markdown and maybe it has a journal entry for only one day, or for the entire week. I'll see, but for now the best solution is to couple the 2 concepts into the same `user_input` file, and have the python script separate them nicely.
+
+#### Implementation
+
+Follow the link to see the Pull Request on GitHub
+
+[PR: Save journal entries from user inputs](https://github.com/szabikr/habit-tracker/pull/3)

--- a/content/proof-of-concepts.md
+++ b/content/proof-of-concepts.md
@@ -1,0 +1,3 @@
+### Proof of Concepts
+
+Implementations that solve well defined problems.

--- a/content/proof-of-concepts/authentication.md
+++ b/content/proof-of-concepts/authentication.md
@@ -1,0 +1,32 @@
+## Motivation
+
+The idea for this proof of concept came when I was implementing a Habit Tracker web application (called Move to Done at the time). In order to release a product like this, the Authentication feature is crucial. I could have configured a Firebase authentication service or any other third party auth provider as a matter of fact, however I wanted to see what's underneath the implementation and see how difficult would it be to develop it for myself.
+
+Have to tell you that it was one of the most challenging proof of concepts that I've ever done. The most challenging part of this project is that the browser is a public space, so when using authentication tokens, there's always a possiblity that somebody steals the token on flight.
+
+Common cyber attacks in the browsers that I considered are:
+
+1. Cross Site Scripting (XSS) - makes storing `access_token` in `localStorage` not viable
+2. Cross Site Request Forgery (CSRF) - makes storing `access_token` in browser cookies not viable
+
+For any authorised requests the user must have an `access_token` which is going to be valid only for a short period of time till they complete the wanted operations i.e. 10mins. This would be a super secure solution as even if the attacker receives this `access_token` they would be able to make only a handful of operations, till the token expires. <br />
+However, in this case the user must authenticate every 10mins which degrades the user experience significantly.
+
+Now you might think, what happens if the attacker gets hold of the `refresh_token`? They could just keep on requesting new access tokens on behalf of the authenticated user. Yeah, that might absolutely happen, this is why the refresh tokens need to be invalidated and recreated with every new `access_token`. On refresh we need to check if the `refresh_token` that a potentially authenticated user provides has already been invalidated. And if so, lock down the account, invalidate all refresh, access tokens and require the user to authenticate. With this method, the attacker won't be able to do anything with the stolen token.
+
+However, there's that possibility that the attacker received the new access token first and replaced the refresh token, and this will only be reveald when the real user tries to get their refreshed access token.
+
+## How it works
+
+The user has to register with their email address and password. The email has to be a unique, valid email address and the password has to contain at least one lowercase, uppercase, number, non alpha numberic character and the length has to be between 8 and 32 characters.
+
+When all the validations are met, the web server hashes the password and creates a username that is just the email address. Saves the user details and the hashed password to the database and returns the email and username.
+
+The password is hashed so that even if attackers get to the database the passwords stay unrevealed.
+
+On login the given password is hashed again and checked against the database. If the hashes and emails match the user will be provided with an `access_token` that they can use to make authenticated requests and a `refresh_token` that they can use to acquire a new `access_token` in case the old one got expired.
+
+In case the `access_token` expires the user can refresh it with their `refresh_token`.
+
+The `refresh_token` (1) must be valid, (2) must not be expired and (3) must not have been used previously. All these validation errors result in an Access Denied. <br />
+If all conditions are met, the user will be granted a new `access_token`, `refresh_token` and the old `refresh_token` will be invalidated, meaning that any refresh api calls made with the old `refresh_token` result in an account lockdown and the user must authenticate again using their credentials.

--- a/content/sandboxes.md
+++ b/content/sandboxes.md
@@ -1,0 +1,7 @@
+### Sandbox repos
+
+This list of repositories represent my trial work. Just as you would sit down next to a pyhisical sandbox and start modifying its content, I try out **software technologies**, **programming languages** with the sole purpose of creating and learning.
+
+Some of the repositories contain work that was inspired by tutorials, courses, articles or videos. So you can dig into the `README.md` files and see if you find something useful for yourself to explore.
+
+I itend to come back to the code that's in these repos in case I want to look things up or expand my knowledge by implementing new ideas.

--- a/content/tutorials.md
+++ b/content/tutorials.md
@@ -1,0 +1,3 @@
+### Tutorials
+
+Challenges to enhance skills of different technologies.

--- a/src/components/projects.jsx
+++ b/src/components/projects.jsx
@@ -1,13 +1,9 @@
 import Link from 'next/link'
 
-export default function Projects({ projects }) {
+export default function Projects({ projects, content }) {
   return (
     <section>
-      <h3>Projects</h3>
-      <p>
-        Work that I'm doing or have done in the past and I consider them usable
-        pieces of software.
-      </p>
+      <div dangerouslySetInnerHTML={{ __html: content }} />
       <ul>
         {projects.map((project) => (
           <li key={project.name}>

--- a/src/components/proof-of-concepts.jsx
+++ b/src/components/proof-of-concepts.jsx
@@ -1,10 +1,9 @@
 import Link from 'next/link'
 
-export default function ProofOfConcepts({ proofOfConcepts }) {
+export default function ProofOfConcepts({ proofOfConcepts, content }) {
   return (
     <section>
-      <h3>Proof of Concepts</h3>
-      <p>Implementations that solve well defined problems.</p>
+      <div dangerouslySetInnerHTML={{ __html: content }} />
       <ul>
         {proofOfConcepts.map((poc) => (
           <li key={poc.name}>

--- a/src/components/sandbox-repos.jsx
+++ b/src/components/sandbox-repos.jsx
@@ -1,24 +1,7 @@
-export default function SandboxRepos({ sandboxRepos }) {
+export default function SandboxRepos({ sandboxRepos, content }) {
   return (
     <section>
-      <h3>Sandbox repos</h3>
-      <p>
-        This list of repositories represent my trial work. Just as you would sit
-        down next to a pyhisical sandbox and start modifying its content, I try
-        out <strong>software technologies</strong>,{' '}
-        <strong>programming languages</strong> with the sole purpose of creating
-        and learning.
-      </p>
-      <p>
-        Some of the repositories contain work that was inspired by tutorials,
-        courses, articles or videos. So you can dig into the{' '}
-        <code>README.md</code> files and see if you find something useful for
-        yourself to explore.
-      </p>
-      <p>
-        I itend to come back to the code that's in these repos in case I want to
-        look things up or expand my knowledge by implementing new ideas.
-      </p>
+      <div dangerouslySetInnerHTML={{ __html: content }} />
       <ul>
         {sandboxRepos.map((repo) => (
           <li key={repo.name}>

--- a/src/components/tutorials.jsx
+++ b/src/components/tutorials.jsx
@@ -1,8 +1,7 @@
-export default function Tutorials({ tutorials }) {
+export default function Tutorials({ tutorials, content }) {
   return (
     <section>
-      <h3>Tutorials</h3>
-      <p>Challenges to enhance skills of different technologies.</p>
+      <div dangerouslySetInnerHTML={{ __html: content }} />
       <ul>
         {tutorials.map((tutorial) => (
           <li key={tutorial.name}>

--- a/src/lib/content-parser.js
+++ b/src/lib/content-parser.js
@@ -5,17 +5,26 @@ import { remark } from 'remark'
 import html from 'remark-html'
 import prism from 'remark-prism'
 
-export async function getHtmlContent(contentPath) {
+// Running remark-prism plugin for every single content parsing causes a slight performance issue
+// So we have to specify it wether the conent needs syntax highlighing or not, by default is set to false
+
+export async function getHtmlContent(contentPath, withSyntaxHl = false) {
   const markdownFilePath = path.join(process.cwd(), 'content', contentPath)
   const markdown = fs.readFileSync(markdownFilePath, 'utf8')
-  const html = await markdownToHtml(markdown)
+  const html = await markdownToHtml(markdown, withSyntaxHl)
   return html
 }
 
-async function markdownToHtml(markdown) {
-  const result = await remark()
-    .use(html, { sanitize: false })
-    .use(prism, { transformInlineCode: true, plugins: ['line-numbers'] })
-    .process(markdown)
+async function markdownToHtml(markdown, withSyntaxHl) {
+  const htmlBuilder = remark().use(html, { sanitize: false })
+
+  if (withSyntaxHl) {
+    htmlBuilder.use(prism, {
+      transformInlineCode: true,
+      plugins: ['line-numbers'],
+    })
+  }
+
+  const result = await htmlBuilder.process(markdown)
   return result.toString()
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,6 +1,7 @@
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 import '../styles/prism-one-light.css'
 import '../styles/main.css'
+import '../styles/inline-code.css'
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,6 +5,7 @@ import Projects from '../components/projects'
 import ProofOfConcepts from '../components/proof-of-concepts'
 import SandboxRepos from '../components/sandbox-repos'
 import Tutorials from '../components/tutorials'
+import { getHtmlContent } from '../lib/content-parser'
 
 export default function App(props) {
   return (
@@ -14,10 +15,22 @@ export default function App(props) {
       </header>
       <main>
         <Profiles />
-        <Projects projects={props.projects} />
-        <ProofOfConcepts proofOfConcepts={props.proofOfConcepts} />
-        <Tutorials tutorials={props.tutorials} />
-        <SandboxRepos sandboxRepos={props.sandboxRepos} />
+        <Projects
+          projects={props.projects}
+          content={props.projectsContentHtml}
+        />
+        <ProofOfConcepts
+          proofOfConcepts={props.proofOfConcepts}
+          content={props.proofOfConceptsContentHtml}
+        />
+        <Tutorials
+          tutorials={props.tutorials}
+          content={props.tutorialsContentHtml}
+        />
+        <SandboxRepos
+          sandboxRepos={props.sandboxRepos}
+          content={props.sandboxesContentHtml}
+        />
       </main>
       <footer></footer>
     </>
@@ -25,12 +38,25 @@ export default function App(props) {
 }
 
 export async function getStaticProps(context) {
+  console.log('starting convert all the markdown content...')
+  const projectsContentHtml = await getHtmlContent('projects.md')
+  const proofOfConceptsContentHtml = await getHtmlContent(
+    'proof-of-concepts.md',
+  )
+  const tutorialsContentHtml = await getHtmlContent('tutorials.md')
+  const sandboxesContentHtml = await getHtmlContent('sandboxes.md')
+  console.log('finished converting all the markdown content...')
+
   return {
     props: {
       projects,
+      projectsContentHtml,
       proofOfConcepts,
+      proofOfConceptsContentHtml,
       tutorials,
+      tutorialsContentHtml,
       sandboxRepos,
+      sandboxesContentHtml,
     },
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,14 +38,17 @@ export default function App(props) {
 }
 
 export async function getStaticProps(context) {
-  console.log('starting convert all the markdown content...')
-  const projectsContentHtml = await getHtmlContent('projects.md')
-  const proofOfConceptsContentHtml = await getHtmlContent(
-    'proof-of-concepts.md',
-  )
-  const tutorialsContentHtml = await getHtmlContent('tutorials.md')
-  const sandboxesContentHtml = await getHtmlContent('sandboxes.md')
-  console.log('finished converting all the markdown content...')
+  const [
+    projectsContentHtml,
+    proofOfConceptsContentHtml,
+    tutorialsContentHtml,
+    sandboxesContentHtml,
+  ] = await Promise.all([
+    getHtmlContent('projects.md'),
+    getHtmlContent('proof-of-concepts.md'),
+    getHtmlContent('tutorials.md'),
+    getHtmlContent('sandboxes.md'),
+  ])
 
   return {
     props: {

--- a/src/pages/projects/habit-tracker.js
+++ b/src/pages/projects/habit-tracker.js
@@ -96,8 +96,10 @@ export default function HabitTracker({ repoLink, refactoringContentHtml }) {
 
 export async function getStaticProps(context) {
   const repoLink = projects.find((poc) => poc.name == 'Habit Tracker').repoLink
+  const withSyntaxHl = true
   const refactoringContentHtml = await getHtmlContent(
     'projects/habit-tracker/refactoring.md',
+    withSyntaxHl,
   )
 
   return {

--- a/src/pages/projects/habit-tracker.js
+++ b/src/pages/projects/habit-tracker.js
@@ -2,7 +2,11 @@ import { getHtmlContent } from '../../lib/content-parser'
 import { projects } from '../../data'
 import GithubAnchor from '../../components/github-anchor'
 
-export default function HabitTracker({ repoLink, refactoringContentHtml }) {
+export default function HabitTracker({
+  repoLink,
+  refactoringContentHtml,
+  changeLogContentHtml,
+}) {
   return (
     <>
       <header>
@@ -12,80 +16,7 @@ export default function HabitTracker({ repoLink, refactoringContentHtml }) {
       <main>
         <section dangerouslySetInnerHTML={{ __html: refactoringContentHtml }} />
         <hr />
-        <section>
-          <h2>Change Log</h2>
-          <h3>v1.0.0 - Activities and Journal Entries</h3>
-          <h4>Motivation</h4>
-          <p>
-            Want to introduce a journaling habit through this project and
-            considered to write my daily journal entries in a separate file
-            called <code>journal.txt</code> and parse that similarly to a{' '}
-            <code>user_input</code> file. However, I think it might just get a
-            little too messy with multiple <code>user_input</code> files, so the
-            solution is the bake the daily journal entries into the already
-            existing <code>user_input</code> file format.
-          </p>
-          <p>
-            This is starting to get closer to the idea of habit journal. Whereby
-            I have my habits, and a journal for each day so that I can introduce
-            a more personal way of recording my activities. Would be nice to see
-            my journal entries in the context of my habits, and see if there's
-            any correlation between the two.
-          </p>
-          <p>
-            And to be honest the editing longer text with the wrap flag on here
-            in Vim doesn't seem that bad. The main reason for this feature is to
-            allow the user to get into the habit of Journaling in a very simple
-            way. There's no need for fancy text editors or cool apps, I think
-            the important bit is to get your thoughts down and be able to dig
-            them up using date filter for example.
-          </p>
-
-          <h4>Theoretical Solution</h4>
-          <p>
-            Currently we have the <code>data.txt</code> file that contains all
-            the data that is entered into the Habits database (activities). Now
-            that we're doing journaling in the same application, we need more
-            complex storage file structure:
-          </p>
-          <ol>
-            <li>
-              <code>activity.txt</code> contains the activities just as how it
-              was the <code>data.txt</code>
-            </li>
-            <li>
-              <code>journal_entry.txt</code> contains the journal entries, with
-              an
-              <code>id</code>, <code>record_date</code> and <code>record</code>
-            </li>
-          </ol>
-          <p>
-            With this I'm creating a dependency to the <code>user_input</code>{' '}
-            files and their parsing. But that's alright, because a CLI needs to
-            be implemented anyway and that can have features that allow users to
-            introduce their activities and journal entries outside of these user
-            files. As long as we agree that the source of truth for the data is
-            the database, or perhaps the database files:{' '}
-            <code>activity.txt</code> and <code>journal.txt</code> at the early
-            stages of the project.
-          </p>
-          <p>
-            Mixing the 2 concepts (<code>activity</code> and{' '}
-            <code>journal_entry</code>) into a single user input file is a good
-            first solution, but later on I can create another file that supports
-            Markdown and maybe it has a journal entry for only one day, or for
-            the entire week. I'll see, but for now the best solution is to
-            couple the 2 concepts into the same <code>user_input</code> file,
-            and have the python script separate them nicely.
-          </p>
-          <h4>Implementation</h4>
-          <p>Follow the link to see the Pull Request on GitHub.</p>
-          <p>
-            <a href="https://github.com/szabikr/habit-tracker/pull/3">
-              PR: Save journal entries from user inputs
-            </a>
-          </p>
-        </section>
+        <section dangerouslySetInnerHTML={{ __html: changeLogContentHtml }} />
       </main>
       <footer>
         <GithubAnchor repoLink={repoLink} />
@@ -97,15 +28,16 @@ export default function HabitTracker({ repoLink, refactoringContentHtml }) {
 export async function getStaticProps(context) {
   const repoLink = projects.find((poc) => poc.name == 'Habit Tracker').repoLink
   const withSyntaxHl = true
-  const refactoringContentHtml = await getHtmlContent(
-    'projects/habit-tracker/refactoring.md',
-    withSyntaxHl,
-  )
+  const [refactoringContentHtml, changeLogContentHtml] = await Promise.all([
+    getHtmlContent('projects/habit-tracker/refactoring.md', withSyntaxHl),
+    getHtmlContent('projects/habit-tracker/change-log.md'),
+  ])
 
   return {
     props: {
       repoLink,
       refactoringContentHtml,
+      changeLogContentHtml,
     },
   }
 }

--- a/src/pages/proof-of-concepts/authentication.js
+++ b/src/pages/proof-of-concepts/authentication.js
@@ -1,7 +1,11 @@
 import { proofOfConcepts } from '../../data'
 import GithubAnchor from '../../components/github-anchor'
+import { getHtmlContent } from '../../lib/content-parser'
 
-export default function Authentication({ repoLink }) {
+export default function Authentication({
+  repoLink,
+  authenticationContentHtml,
+}) {
   return (
     <>
       <header>
@@ -9,108 +13,9 @@ export default function Authentication({ repoLink }) {
         <GithubAnchor repoLink={repoLink} />
       </header>
       <main>
-        <section>
-          <h2>Motivation</h2>
-          <p>
-            The idea for this proof of concept came when I was implementing a
-            Habit Tracker web application (called Move to Done at the time). In
-            order to release a product like this, the Authentication feature is
-            crucial. I could have configured a Firebase authentication service
-            or any other third party auth provider as a matter of fact, however
-            I wanted to see what's underneath the implementation and see how
-            difficult would it be to develop it for myself.
-          </p>
-          <p>
-            Have to tell you that it was one of the most challenging proof of
-            concepts that I've ever done. The most challenging part of this
-            project is that the browser is a public space, so when using
-            authentication tokens, there's always a possiblity that somebody
-            steals the token on flight.
-          </p>
-          Common cyber attacks in the browsers that I considered are:
-          <ol>
-            <li>
-              Cross Site Scripting (XSS) - makes storing{' '}
-              <code>access_token</code> in <code>localStorage</code> not viable
-            </li>
-            <li>
-              Cross Site Request Forgery (CSRF) - makes storing{' '}
-              <code>access_token</code> in browser cookies not viable
-            </li>
-          </ol>
-          <p>
-            For any authorised requests the user must have an{' '}
-            <code>access_token</code> which is going to be valid only for a
-            short period of time till they complete the wanted operations i.e.
-            10mins. This would be a super secure solution as even if the
-            attacker receives this <code>access_token</code> they would be able
-            to make only a handful of operations, till the token expires. <br />
-            However, in this case the user must authenticate every 10mins which
-            degrades the user experience significantly.
-          </p>
-          <p>
-            Now you might think, what happens if the attacker gets hold of the{' '}
-            <code>refresh_token</code>? They could just keep on requesting new
-            access tokens on behalf of the authenticated user. Yeah, that might
-            absolutely happen, this is why the refresh tokens need to be
-            invalidated and recreated with every new <code>access_token</code>.
-            On refresh we need to check if the <code>refresh_token</code> that a
-            potentially authenticated user provides has already been
-            invalidated. And if so, lock down the account, invalidate all
-            refresh, access tokens and require the user to authenticate. With
-            this method, the attacker won't be able to do anything with the
-            stolen token.
-          </p>
-          <p>
-            However, there's that possibility that the attacker received the new
-            access token first and replaced the refresh token, and this will
-            only be reveald when the real user tries to get their refreshed
-            access token.
-          </p>
-        </section>
-        <section>
-          <h2>How it works</h2>
-          <p>
-            The user has to register with their email address and password. The
-            email has to be a unique, valid email address and the password has
-            to contain at least one lowercase, uppercase, number, non alpha
-            numberic character and the length has to be between 8 and 32
-            characters.
-          </p>
-          <p>
-            When all the validations are met, the web server hashes the password
-            and creates a username that is just the email address. Saves the
-            user details and the hashed password to the database and returns the
-            email and username.
-          </p>
-          <p>
-            The password is hashed so that even if attackers get to the database
-            the passwords stay unrevealed.
-          </p>
-          <p>
-            On login the given password is hashed again and checked against the
-            database. If the hashes and emails match the user will be provided
-            with an <code>access_token</code> that they can use to make
-            authenticated requests and a <code>refresh_token</code> that they
-            can use to acquire a new <code>access_token</code> in case the old
-            one got expired.
-          </p>
-          <p>
-            In case the <code>access_token</code> expires the user can refresh
-            it with their <code>refresh_token</code>.
-          </p>
-          <p>
-            The <code>refresh_token</code> (1) must be valid, (2) must not be
-            expired and (3) must not have been used previously. All these
-            validation errors result in an Access Denied. <br />
-            If all conditions are met, the user will be granted a new{' '}
-            <code>access_token</code>, <code>refresh_token</code> and the old{' '}
-            <code>refresh_token</code> will be invalidated, meaning that any
-            refresh api calls made with the old <code>refresh_token</code>{' '}
-            result in an account lockdown and the user must authenticate again
-            using their credentials.
-          </p>
-        </section>
+        <section
+          dangerouslySetInnerHTML={{ __html: authenticationContentHtml }}
+        />
       </main>
       <footer>
         <GithubAnchor repoLink={repoLink} />
@@ -123,7 +28,10 @@ export async function getStaticProps(context) {
   const repoLink = proofOfConcepts.find(
     (poc) => poc.name == 'Authentication',
   ).repoLink
+  const authenticationContentHtml = await getHtmlContent(
+    'proof-of-concepts/authentication.md',
+  )
   return {
-    props: { repoLink },
+    props: { repoLink, authenticationContentHtml },
   }
 }

--- a/src/styles/inline-code.css
+++ b/src/styles/inline-code.css
@@ -1,0 +1,36 @@
+:not(pre) > code {
+  background: hsl(230, 1%, 98%);
+  color: hsl(230, 8%, 24%);
+  font-family: 'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono',
+    monospace;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+  -moz-tab-size: 2;
+  -o-tab-size: 2;
+  tab-size: 2;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+
+  padding: 0.2em 0.3em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+/* Selection */
+:not(pre) > code::-moz-selection,
+:not(pre) > code *::-moz-selection {
+  background: hsl(230, 1%, 90%);
+  color: inherit;
+}
+
+:not(pre) > code::selection,
+:not(pre) > code *::selection {
+  background: hsl(230, 1%, 90%);
+  color: inherit;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -38,6 +38,43 @@ p strong {
   font-weight: 800;
 }
 
+:not(pre) > code {
+  background: hsl(230, 1%, 98%);
+  color: hsl(230, 8%, 24%);
+  font-family: 'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono',
+    monospace;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+  -moz-tab-size: 2;
+  -o-tab-size: 2;
+  tab-size: 2;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+
+  padding: 0.2em 0.3em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+/* Selection */
+code::-moz-selection,
+code *::-moz-selection {
+  background: hsl(230, 1%, 90%);
+  color: inherit;
+}
+
+code::selection,
+code *::selection {
+  background: hsl(230, 1%, 90%);
+  color: inherit;
+}
+
 @media only screen and (max-width: 768px) {
   main,
   header,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -38,43 +38,6 @@ p strong {
   font-weight: 800;
 }
 
-:not(pre) > code {
-  background: hsl(230, 1%, 98%);
-  color: hsl(230, 8%, 24%);
-  font-family: 'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono',
-    monospace;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  line-height: 1.5;
-  -moz-tab-size: 2;
-  -o-tab-size: 2;
-  tab-size: 2;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-
-  padding: 0.2em 0.3em;
-  border-radius: 0.3em;
-  white-space: normal;
-}
-
-/* Selection */
-code::-moz-selection,
-code *::-moz-selection {
-  background: hsl(230, 1%, 90%);
-  color: inherit;
-}
-
-code::selection,
-code *::selection {
-  background: hsl(230, 1%, 90%);
-  color: inherit;
-}
-
 @media only screen and (max-width: 768px) {
   main,
   header,


### PR DESCRIPTION
### Motivation

Want to have all the content that is possible in the same format inside of the `content` folder so that I can deal with all pieces of content the same way.

### Solution

- Moving all content from index page into their markdown files
- Reading the markdown files and parsing them to HTML
- Passing the content down as props

### Additional changes

- `withSyntaxHl` flag: Provides the option to opt-out from prism syntax highlighting for markdown files that do not have code blocks for some performance gains.