### PR TITLE
Scroll Experience Content Header to The Top of Screen When Expanded

### DIFF
--- a/src/components/experience/accordion.tsx
+++ b/src/components/experience/accordion.tsx
@@ -1,15 +1,37 @@
-import { useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { AccordionProps } from '../../types/props'
 
 export default function Accordion({ items, openByDefault }: AccordionProps) {
   const [show, setShow] = useState(openByDefault)
+  const accordionRef = useRef(null)
+  const didMount = useRef(false)
 
   const toggleItem = (id: string) => (show === id ? setShow(null) : setShow(id))
 
+  useEffect(() => {
+    // Do not run on first render
+    if (!didMount.current) {
+      didMount.current = true
+      return
+    }
+
+    if (show === null) {
+      return
+    }
+
+    const accordionNode = accordionRef.current
+    const itemNode = accordionNode.querySelector(`#accordion-item-${show}`)
+    itemNode.scrollIntoView({ behavior: 'smooth' })
+  }, [show])
+
   return (
-    <div className="accordion">
+    <div className="accordion" ref={accordionRef}>
       {items.map((item) => (
-        <div key={item.id} className="accordion-item">
+        <div
+          key={item.id}
+          id={`accordion-item-${item.id}`}
+          className="accordion-item"
+        >
           <div className="accordion-header">
             {item.header(item.id != show)}
             <div>


### PR DESCRIPTION
- `useRef` combined with `useEffect` makes sure that we only scroll when the accordion state has actually changed and not on first render
- Uses Query Selector that checks for `item.id` to determine which item should be visible